### PR TITLE
Bump to 2.6.1

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -3,8 +3,8 @@ from conans import ConanFile, tools, CMake
 
 class PyBind11Conan(ConanFile):
     name = "pybind11"
-    upstream_version = "2.2.4"
-    revision = "1"
+    upstream_version = "2.6.1"
+    revision = "0"
     version = "{}-{}".format(upstream_version, revision)
     settings = "os", "compiler", "arch", "build_type"
     description = "Seamless operability between C++11 and Python"


### PR DESCRIPTION
We're using a quite old version (2.2.4): https://pybind11.readthedocs.io/en/stable/changelog.html

This will upload the latest through the conan-builder: https://builder.ci.pix4d.com/teams/developers/pipelines/conan-builder-bump-pybind11-to-2.6

@sambarluc seems that pybind11 is now on PyPI with some setuptools extension: https://pybind11.readthedocs.io/en/stable/compiling.html#build-setuptools But that probably doesn't help us with all the stuff we need to pull from conan.

