### PR TITLE
Upgrade version to 2.10.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, tools, CMake
 
 class PyBind11Conan(ConanFile):
     name = "pybind11"
-    upstream_version = "2.9.2"
+    upstream_version = "2.10.0"
     revision = "0"
     version = "{}-{}".format(upstream_version, revision)
     settings = "os", "compiler", "arch", "build_type"


### PR DESCRIPTION
Second try. Apparently the release branches have no history in common with `stable`, so I guess we'll have to stick to the `release/2.10` branches at least for now. See PR #4 (that for some reason I cannot re-open).