### PR TITLE
Upgrade pybind11 to the latest released version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,9 +1,9 @@
-from conans import ConanFile, tools, CMake
+from conans import CMake, ConanFile, tools
 
 
 class PyBind11Conan(ConanFile):
     name = "pybind11"
-    upstream_version = "2.12.0"
+    upstream_version = "2.13.6"
     revision = "0"
     version = "{}-{}".format(upstream_version, revision)
     settings = "os", "compiler", "arch", "build_type"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 project(test_package CXX)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)


### PR DESCRIPTION
We are using a rather old version, so it makes sense to upgrade the library while supporting cmake 4. 2.12 also gets cmake 4 support in PR #7.

[AN-3213](https://pix4dbug.atlassian.net/browse/AN-3213)

[AN-3213]: https://pix4dbug.atlassian.net/browse/AN-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ